### PR TITLE
Fix unpack pattern matching

### DIFF
--- a/cmd/pack.go
+++ b/cmd/pack.go
@@ -135,9 +135,6 @@ func Unpack() *cobra.Command {
 
 			destFS := afero.NewOsFs()
 
-			if pattern != "" {
-				pattern = "**100/" + pattern
-			}
 			return afero.Walk(srcFS, "/", func(srcPath string, info os.FileInfo, err error) error {
 				if err != nil {
 					log.Println(err)
@@ -148,9 +145,8 @@ func Unpack() *cobra.Command {
 				}
 
 				fullPath := filepath.ToSlash(srcPath)
-
 				if pattern != "" {
-					match, err := glob.Match(pattern, fullPath)
+					match, err := glob.Match("**100/" + pattern, fullPath)
 					if err != nil {
 						return err
 					}

--- a/cmd/pack.go
+++ b/cmd/pack.go
@@ -146,7 +146,7 @@ func Unpack() *cobra.Command {
 
 				fullPath := filepath.ToSlash(srcPath)
 				if pattern != "" {
-					match, err := glob.Match("**100/" + pattern, fullPath)
+					match, err := glob.Match("**100/"+pattern, fullPath)
 					if err != nil {
 						return err
 					}

--- a/cmd/pack.go
+++ b/cmd/pack.go
@@ -134,7 +134,10 @@ func Unpack() *cobra.Command {
 			defer teardown()
 
 			destFS := afero.NewOsFs()
-			pattern = "**100/" + pattern
+
+			if pattern != "" {
+				pattern = "**100/" + pattern
+			}
 			return afero.Walk(srcFS, "/", func(srcPath string, info os.FileInfo, err error) error {
 				if err != nil {
 					log.Println(err)


### PR DESCRIPTION
Unpacking with a default `match` parameter doesn't work at all, because the resulting pattern doesn't match any file. 